### PR TITLE
Fix unable to clone jstraining via ssh for Mac

### DIFF
--- a/docs/preparation.md
+++ b/docs/preparation.md
@@ -46,7 +46,7 @@ Postman 是一个 HTTP 通信测试工具，REST API 的练习会用到它。
 
 ```bash
 # Linux & Mac
-$ git clone git@github.com:ruanyf/jstraining.git
+$ git clone https://github.com/ruanyf/jstraining.git
 
 # Windows
 $ git clone https://github.com/ruanyf/jstraining.git


### PR DESCRIPTION
When cloning jstraining in Mac with git clone git@github.com:ruanyf/jstraining.git, error occurs.

$ git clone git@github.com:ruanyf/jstraining.git
Cloning into 'jstraining'...
Permission denied (publickey).
fatal: Could not read from remote repository.

So it's better to use https to clone the repository.